### PR TITLE
remove const ui from SwaggerUIBundle init

### DIFF
--- a/render_swagger.py
+++ b/render_swagger.py
@@ -19,9 +19,9 @@ TEMPLATE = string.Template("""
 </div>
 <script src="$swagger_lib_js" charset="UTF-8"></script>
 <script>
-    const ui = SwaggerUIBundle({
-    url: '$path',
-    dom_id: '#swagger-ui',
+    SwaggerUIBundle({
+      url: '$path',
+      dom_id: '#swagger-ui',
     })
 </script>
 


### PR DESCRIPTION
We use several OpenApi specifications on one mcdocs site and when switching between pages with API get an error in javascript on second and next pages:

```
VM19: 1 Uncaught SyntaxError: Identifier 'ui' has already been declared
at ze (bundle.b1047164.min.js: 27)
at bundle.b1047164.min.js: 27
at v (bundle.b1047164.min.js: 27)
at K (bundle.b1047164.min.js: 27)
at t.onFinalize (bundle.b1047164.min.js: 27)
at t.unsubscribe (bundle.b1047164.min.js: 27)
at t.s._complete (bundle.b1047164.min.js: 27)
at t.complete (bundle.b1047164.min.js: 27)
at HTMLScriptElement.p.onload (bundle.b1047164.min.js: 27)
```

This error is corrected by reloading the page in the browser by F5.
This PR solved this problem.