### PR TITLE
Bump swagger-ui from v3 to v5 (ref #23)

### DIFF
--- a/render_swagger.py
+++ b/render_swagger.py
@@ -42,8 +42,8 @@ def swagger_lib(config) -> dict:
     Provides the actual swagger library used
     """
     lib_swagger = {
-        'css': "https://unpkg.com/swagger-ui-dist@3/swagger-ui.css",
-        'js': "https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"
+        'css': "https://unpkg.com/swagger-ui-dist@5/swagger-ui.css",
+        'js': "https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"
     }
 
     extra_javascript = config.get('extra_javascript', [])


### PR DESCRIPTION
I'm proposing to bump swagger-ui version from v3 to v5, so that it also includes support for OpenAPI 3.1.0.
Closes #23.