### PR TITLE
MkDocs 1.5.2+ compat

### DIFF
--- a/render_swagger.py
+++ b/render_swagger.py
@@ -64,6 +64,7 @@ def swagger_lib(config) -> dict:
     extra_javascript = config.get('extra_javascript', [])
     extra_css = config.get('extra_css', [])
     for lib in extra_javascript:
+        lib = str(lib)  # Can be an instance of ExtraScriptValue
         if os.path.basename(
                 urllib.parse.urlparse(lib).path) == 'swagger-ui-bundle.js':
             import warnings


### PR DESCRIPTION
See https://oprypin.github.io/mkdocs/about/release-notes/#version-152-2023-08-02

Before :

```
DEBUG   -  Running `config` event from plugin 'render_swagger'
Traceback (most recent call last):
  File "/home/build/venv/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/build/venv/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/venv/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/build/venv/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/venv/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/venv/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/venv/lib/python3.12/site-packages/mkdocs/__main__.py", line 284, in build_command
    build.build(cfg, dirty=not clean)
  File "/home/build/venv/lib/python3.12/site-packages/mkdocs/commands/build.py", line 265, in build
    config = config.plugins.on_config(config)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/venv/lib/python3.12/site-packages/mkdocs/plugins.py", line 587, in on_config
    return self.run_event('config', config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/venv/lib/python3.12/site-packages/mkdocs/plugins.py", line 566, in run_event
    result = method(item, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/venv/lib/python3.12/site-packages/render_swagger.py", line 97, in on_config
    lib = swagger_lib(config)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/build/venv/lib/python3.12/site-packages/render_swagger.py", line 68, in swagger_lib
    urllib.parse.urlparse(lib).path) == 'swagger-ui-bundle.js':
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/urllib/parse.py", line 394, in urlparse
    url, scheme, _coerce_result = _coerce_args(url, scheme)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/urllib/parse.py", line 133, in _coerce_args
    return _decode_args(args) + (_encode_result,)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/urllib/parse.py", line 117, in _decode_args
    return tuple(x.decode(encoding, errors) if x else '' for x in args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/urllib/parse.py", line 117, in <genexpr>
    return tuple(x.decode(encoding, errors) if x else '' for x in args)
                 ^^^^^^^^
AttributeError: 'ExtraScriptValue' object has no attribute 'decode'
```